### PR TITLE
update /etc/default/inadyn to start daemon

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,3 +26,11 @@
     cmd: inadyn --check-config -f "{{ __inadyn_config_path }}"
   when: inadyn_check_config is defined and inadyn_check_config
   changed_when: false
+
+- name: Enable inadyn daemon
+  ansible.builtin.lineinfile:
+    regexp: '^RUN_DAEMON='
+    line: 'RUN_DAEMON="yes"'
+    path: /etc/default/inadyn
+  when: not inadyn_install_source
+  notify: Restart inadyn


### PR DESCRIPTION
Ran into an issue on Debian trixie where `/etc/default/inadyn` has a failsafe var `RUN_DAEMON="no"` that needs to be updated before the daemon will start.

Added lineinfile task to make adjustment and notify when not installing from source

```
Sep 13 01:57:05 clammy-ng systemd[1]: Starting inadyn.service - LSB: DynDNS client...
Sep 13 01:57:05 clammy-ng inadyn[300862]: inadyn: Not starting. Disabled in /etc/default/inadyn.
Sep 13 01:57:05 clammy-ng systemd[1]: Started inadyn.service - LSB: DynDNS client.
Sep 13 01:57:34 clammy-ng systemd[1]: Stopping inadyn.service - LSB: DynDNS client...
```

```
root@clammy-ng:/etc/default# cat inadyn
# Please note, /etc/inadyn.conf should be properly configured before
# running inadyn

# Set to "yes" if inadyn should run in daemon mode
# If this is changed to "yes", RUN_IPUP must be set to "no".
RUN_DAEMON="no"

# Set to "yes" if inadyn should be run every time a new ppp connection is
# established. This might be useful, if you are using dial-on-demand.
RUN_IPUP="no"

# The user and group that inadyn should be run as.
USER="debian-inadyn"
GROUP="debian-inadyn"
```