### PR TITLE
Implement allow-ipv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-Role Name
-=========
+# Role Name
 
 This role installs and configures [inadyn](https://github.com/troglobit/inadyn)
 
-Requirements
-------------
+## Requirements
 
 None.
 
-Role Variables
---------------
+## Role Variables
 
 `inadyn_perdiod`: Update interval
 
@@ -18,6 +15,8 @@ Role Variables
 `inadyn_version`: Version to install. Only required when building from source.
 
 `inadyn_install_source`: Whether to install inadyn from source
+
+`inadyn_allow_ipv6`: Whether to allow IPv6 for inadyn updates.
 
 `inadyn_providers`: List of providers to add to the configuration. The following fields are available:
 
@@ -37,14 +36,11 @@ Role Variables
     - ddns_path
     - index: Indice to add when multiple provider of the same name are given
 
-
-Dependencies
-------------
+## Dependencies
 
 None
 
-Example Playbook
-----------------
+## Example Playbook
 
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 
@@ -54,6 +50,7 @@ Including an example of how to use your role (for instance, with variables passe
       vars:
         inadyn_install_source: true
         inadyn_version: 2.10.0
+        inadyn_allow_ipv6: true
         inadyn_providers:
             - name: freedns
               username: freedns_user1
@@ -71,14 +68,11 @@ Including an example of how to use your role (for instance, with variables passe
               password: snoopy
               hostname: "{ peanuts,woodstock }"
               user_agent: "Mozilla/4.0"
-    
 
-License
--------
+## License
 
 GNU General Public License v3.0
 
-Author Information
-------------------
+## Author Information
 
 [Github](https://github.com/mivek)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,5 +6,6 @@ inadyn_user_agent: "Mozilla/5.0"
 inadyn_install_source: false
 inadyn_check_config: true
 inadyn_version: 2.11.0
+inadyn_allow_ipv6: false
 
 inadyn_providers: []

--- a/molecule/default/inventory/host_vars/instance2.yml
+++ b/molecule/default/inventory/host_vars/instance2.yml
@@ -1,7 +1,7 @@
 ---
-
 inadyn_install_source: true
 inadyn_version: 2.10.0
+inadyn_allow_ipv6: true
 inadyn_providers:
   - name: freedns
     username: freedns_user1

--- a/templates/inadyn.conf.j2
+++ b/templates/inadyn.conf.j2
@@ -3,6 +3,7 @@
 # In-A-Dyn v2.0 configuration file format
 period            = {{ inadyn_period }}
 user-agent        = {{ inadyn_user_agent }}
+allow-ipv6        = {{ inadyn_allow_ipv6 }}
 
 {% for provider in inadyn_providers %}
 provider {{ provider.name }}{% if provider.index is defined and provider.index %}:{{ provider.index }}{% endif %} {


### PR DESCRIPTION
inadyn requires the option allow-ipv6 to update AAAA entries. This PR adds the option `inadyn_allow_ipv6` to the configuration, to set it.