### PR TITLE
Change config file permissions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,8 +17,8 @@
     src: inadyn.conf.j2
     dest: "{{ __inadyn_config_path }}"
     owner: root
-    group: root
-    mode: 0644
+    group: debian-inadyn
+    mode: 0640
   notify: Restart inadyn
 
 - name: Test the configuration


### PR DESCRIPTION
The config file is currently world readable. As the file will most certainly contain credentials, it should not be world readable. Additionally the default group for the file on debian based systems is `debian-inadyn`. This PR changes both to the debian defaults. 