### PR TITLE
Fix jinja2 block trimming syntax in inadyn.conf.j2

### DIFF
--- a/templates/inadyn.conf.j2
+++ b/templates/inadyn.conf.j2
@@ -1,4 +1,4 @@
-#jinja2: trim_blocks: "true", lstrip_blocks: "false"
+#jinja2: trim_blocks:True, lstrip_blocks:False
 #{{ ansible_managed }}
 
 # In-A-Dyn v2.0 configuration file format


### PR DESCRIPTION
The syntax in the jinja2 config line is incorrect. The booleans must start with an uppercase letter.